### PR TITLE
add rename to Adafruit_SPIFlash_FatFs

### DIFF
--- a/Adafruit_SPIFlash_FatFs.cpp
+++ b/Adafruit_SPIFlash_FatFs.cpp
@@ -255,6 +255,11 @@ bool Adafruit_SPIFlash_FatFs::exists(const char *filepath) {
   return f_stat(filepath, NULL) == FR_OK;
 }
 
+bool Adafruit_SPIFlash_FatFs::rename(const char *oldPath, const char *newPath) {
+  activate();
+  return f_rename(oldPath, newPath) == FR_OK;
+}
+
 bool Adafruit_SPIFlash_FatFs::mkdir(const char *filepath) {
   activate();
   // Check the path to create can be fit inside a buffer.

--- a/Adafruit_SPIFlash_FatFs.h
+++ b/Adafruit_SPIFlash_FatFs.h
@@ -121,6 +121,10 @@ public:
   bool exists(const String &filepath) {
     return exists(filepath.c_str());
   }
+  bool rename(const char *oldPath, const char *newPath);
+  bool rename(const String &oldPath, const String &newPath) {
+    return rename(oldPath.c_str(), newPath.c_str());
+  }
   bool mkdir(const char *filepath);
   bool mkdir(const String &filepath) {
     return mkdir(filepath.c_str());


### PR DESCRIPTION
This rename works the same way that rename works in later versions
of Adafruit_SPIFlash.